### PR TITLE
Android: Decrease minsdk from 24 to 23 

### DIFF
--- a/kotlin-json-patch/build.gradle.kts
+++ b/kotlin-json-patch/build.gradle.kts
@@ -50,6 +50,6 @@ android {
     namespace = "com.reidsync.kxjsonpatch"
     compileSdk = 34
     defaultConfig {
-        minSdk = 24
+        minSdk = 23
     }
 }


### PR DESCRIPTION
We want to use this library in our project. However, it is minSdk 24 and we need minSdk 23. I currently override it in the AndroidManifest.xml but we would prefer to not do that.

It seems 24 is just a arbitrary chosen value, and I don't see anything failing due to this decrease. So therefor a simple PR.